### PR TITLE
fix EOF infinite loop

### DIFF
--- a/plexus-interactivity-api/src/main/java/org/codehaus/plexus/components/interactivity/DefaultPrompter.java
+++ b/plexus-interactivity-api/src/main/java/org/codehaus/plexus/components/interactivity/DefaultPrompter.java
@@ -121,6 +121,9 @@ public class DefaultPrompter
             try
             {
                 line = inputHandler.readLine();
+                if (line == null && defaultReply == null) {
+                    throw new IOException("EOF");
+                }
             }
             catch ( IOException e )
             {


### PR DESCRIPTION
When running maven with stdin redirected to /dev/null or nul and connecting to unknown host, it repeats the host key prompt infininitely. See https://issues.apache.org/jira/browse/WAGON-494
