### PR TITLE
Adding dependencyManagement information for the version of dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,4 +51,18 @@
     </plugins>
   </build>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>3.3.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-container-default</artifactId>
+        <version>2.1.1</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 </project>


### PR DESCRIPTION
By adding version information, the shipped POMs will also include version info and then reverse dependencies of plexus-interactivity shall be provided with complete Maven coordinates.

For instance I was building the latest upstream version of Byte Buddy and got the following message:

[INFO] --- maven-javadoc-plugin:3.0.1:jar (default-cli) @ byte-buddy-parent ---
[WARNING] The POM for org.codehaus.plexus:plexus-interactivity-api:jar:debian is invalid, transitive dependencies (if any) will not be available: 2 problems were encountered while building the effective model fo
r org.codehaus.plexus:plexus-interactivity-api:debian
[ERROR] 'dependencies.dependency.version' for org.codehaus.plexus:plexus-utils:jar is missing. @
[ERROR] 'dependencies.dependency.version' for org.codehaus.plexus:plexus-container-default:jar is missing. @

The current PR allowed me to fix this issue.

Best,
Pierre